### PR TITLE
Add panther-x2 support

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -130,6 +130,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-evb3-ddr3-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-evb3-ddr3-v10-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-evb5-lp4x-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-jp-tvbox.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-panther-x2.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-radxa-cm3-io.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-radxa-cm3-rpi-cm4-io.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-radxa-cm3-sodimm-io.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts
@@ -565,3 +565,6 @@
     status = "okay";
 };
 
+&u2phy0_host {
+    status = "okay";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts
@@ -553,11 +553,6 @@
     status = "okay";
 };
 
-&usb_host0_xhci {
-    dr_mode = "host";
-    status = "okay";
-};
-
 &usb_host0_ohci {
     status = "okay";
 };
@@ -567,14 +562,6 @@
 };
 
 &usb2phy0 {
-    status = "okay";
-};
-
-&usb2phy0_host {
-    status = "okay";
-};
-
-&usb2phy0_otg {
     status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2023 tdleiyao <tdleiyao@gmail.com>
+ */
+ 
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include "rk3566.dtsi"
+
+/ {
+    model = "Panther X2";
+    compatible = "panther,x2", "rockchip,rk3566";
+
+    aliases {
+        ethernet0 = &gmac1;
+        mmc0 = &sdmmc0;
+        mmc1 = &sdhci;
+        mmc2 = &sdmmc1;
+    };
+
+    chosen: chosen {
+        stdout-path = "serial2:1500000n8";
+    };
+
+    gmac1_clkin: external-gmac1-clock {
+        compatible = "fixed-clock";
+        clock-frequency = <125000000>;
+        clock-output-names = "gmac1_clkin";
+        #clock-cells = <0>;
+    };
+
+    leds {
+        compatible = "gpio-leds";
+    //Corresponds to the actual order
+        led_pwr: led-pwr {
+            label = "led-pwr";
+            default-state = "on";
+            gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&led_pwr_enable_h>;
+            retain-state-suspended;
+            status = "okay";
+        };
+        
+        led_wifi: led-wifi {
+            label = "led-wifi";
+            default-state = "off";
+            gpios = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&led_wifi_enable_h>;
+            retain-state-suspended;
+            status = "okay";
+        };
+        
+        led_eth: led-eth {
+            label = "led-eth";
+            default-state = "off";
+            gpios = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
+            pinctrl-names = "default";
+            pinctrl-0 = <&led_eth_enable_h>;
+            retain-state-suspended;
+            status = "okay";
+        };
+        
+        led_status: led-status {
+            label = "led-status";
+            default-state = "on";
+            gpios = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
+            linux,default-trigger = "heartbeat";
+            pinctrl-names = "default";
+            pinctrl-0 = <&led_status_enable_h>;
+            retain-state-suspended;
+            status = "okay";
+        };
+    };
+    
+    vbus: vbus-regulator {
+        compatible = "regulator-fixed";
+        regulator-name = "vbus";
+        regulator-always-on;
+        regulator-boot-on;
+        regulator-min-microvolt = <5000000>;
+        regulator-max-microvolt = <5000000>;
+    };
+
+    vcc5v0_sys: vcc5v0-sys-regulator {
+        compatible = "regulator-fixed";
+        regulator-name = "vcc5v0_sys";
+        regulator-always-on;
+        regulator-boot-on;
+        regulator-min-microvolt = <5000000>;
+        regulator-max-microvolt = <5000000>;
+        vin-supply = <&vbus>;
+    };
+
+    vcc3v3_sys: vcc3v3-sys-regulator {
+        compatible = "regulator-fixed";
+        regulator-name = "vcc3v3_sys";
+        regulator-always-on;
+        regulator-boot-on;
+        regulator-min-microvolt = <3300000>;
+        regulator-max-microvolt = <3300000>;
+        vin-supply = <&vcc5v0_sys>;
+    };
+
+    sdio_pwrseq: sdio-pwrseq {
+        status = "okay";
+        compatible = "mmc-pwrseq-simple";
+        clocks = <&rk809 1>;
+        clock-names = "ext_clock";
+        pinctrl-names = "default";
+        pinctrl-0 = <&wifi_enable_h>;
+        reset-gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_LOW>;
+        post-power-on-delay-ms = <100>;
+    };
+
+    wireless_wlan: wireless-wlan {
+        compatible = "wlan-platdata";
+        rockchip,grf = <&grf>;
+        wifi_chip_type = "ap6236";
+        pinctrl-names = "default";
+        pinctrl-0 = <&wifi_host_wake_irq>;
+        WIFI,host_wake_irq = <&gpio2 RK_PB2 GPIO_ACTIVE_HIGH>;
+        status = "okay";
+    };
+
+};
+
+&cpu0 {
+    cpu-supply = <&vdd_cpu>;
+};
+
+&cpu1 {
+    cpu-supply = <&vdd_cpu>;
+};
+
+&cpu2 {
+    cpu-supply = <&vdd_cpu>;
+};
+
+&cpu3 {
+    cpu-supply = <&vdd_cpu>;
+};
+
+&gpu {
+       mali-supply = <&vdd_gpu>;
+       status = "okay";
+};
+
+&gmac1 {
+    assigned-clocks = <&cru SCLK_GMAC1_RX_TX>, <&cru SCLK_GMAC1_RGMII_SPEED>, <&cru SCLK_GMAC1>;
+    assigned-clock-parents = <&cru SCLK_GMAC1_RGMII_SPEED>, <&cru SCLK_GMAC1>, <&gmac1_clkin>;
+    clock_in_out = "input";
+    phy-supply = <&vcc_3v3>;
+    phy-mode = "rgmii";
+    pinctrl-names = "default";
+    pinctrl-0 = <&gmac1m0_miim
+             &gmac1m0_tx_bus2
+             &gmac1m0_rx_bus2
+             &gmac1m0_rgmii_clk
+             &gmac1m0_clkinout
+             &gmac1m0_rgmii_bus>;
+    snps,reset-gpio = <&gpio3 RK_PA1 GPIO_ACTIVE_LOW>;
+    snps,reset-active-low;
+    /* Reset time is 20ms, 100ms for rtl8211f, also works well here */
+    snps,reset-delays-us = <0 20000 100000>;
+    tx_delay = <0x30>;
+    rx_delay = <0x10>;
+    phy-handle = <&rgmii_phy1>;
+    status = "okay";
+};
+&mdio1 {
+    rgmii_phy1: ethernet-phy@0 {
+        compatible = "ethernet-phy-ieee802.3-c22";
+        reg = <0>;
+        status = "okay";
+    };
+};
+
+&i2c0 {
+    status = "okay";
+
+    vdd_cpu: regulator@1c {
+        compatible = "tcs,tcs4525";
+        reg = <0x1c>;
+        fcs,suspend-voltage-selector = <1>;
+        regulator-name = "vdd_cpu";
+        regulator-min-microvolt = <800000>;
+        regulator-max-microvolt = <1150000>;
+        regulator-ramp-delay = <2300>;
+        regulator-always-on;
+        regulator-boot-on;
+        vin-supply = <&vcc5v0_sys>;
+
+        regulator-state-mem {
+            regulator-off-in-suspend;
+        };
+    };
+
+    rk809: pmic@20 {
+        compatible = "rockchip,rk809";
+        reg = <0x20>;
+        interrupt-parent = <&gpio0>;
+        interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
+        #clock-cells = <1>;
+        clock-output-names = "rk808-clkout1", "rk808-clkout2";
+        pinctrl-names = "default";
+        pinctrl-0 = <&pmic_int_l>;
+        rockchip,system-power-controller;
+        wakeup-source;
+
+        vcc1-supply = <&vcc3v3_sys>;
+        vcc2-supply = <&vcc3v3_sys>;
+        vcc3-supply = <&vcc3v3_sys>;
+        vcc4-supply = <&vcc3v3_sys>;
+        vcc5-supply = <&vcc3v3_sys>;
+        vcc6-supply = <&vcc3v3_sys>;
+        vcc7-supply = <&vcc3v3_sys>;
+        vcc8-supply = <&vcc3v3_sys>;
+        vcc9-supply = <&vcc3v3_sys>;
+
+        regulators {
+            vdd_logic: DCDC_REG1 {
+                regulator-name = "vdd_logic";
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <500000>;
+                regulator-max-microvolt = <1350000>;
+                regulator-init-microvolt = <900000>;
+                regulator-ramp-delay = <6001>;
+                regulator-initial-mode = <0x2>;
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                    regulator-suspend-microvolt = <900000>;
+                };
+            };
+
+            vdd_gpu: DCDC_REG2 {
+                regulator-name = "vdd_gpu";
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <500000>;
+                regulator-max-microvolt = <1350000>;
+                regulator-init-microvolt = <900000>;
+                regulator-ramp-delay = <6001>;
+                regulator-initial-mode = <0x2>;
+                    regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcc_ddr: DCDC_REG3 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-initial-mode = <0x2>;
+                regulator-name = "vcc_ddr";
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                };
+            };
+
+            vdd_npu: DCDC_REG4 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <500000>;
+                regulator-max-microvolt = <1350000>;
+                regulator-init-microvolt = <900000>;
+                regulator-initial-mode = <0x2>;
+                regulator-name = "vdd_npu";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcc_1v8: DCDC_REG5 {
+                regulator-name = "vcc_1v8";
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <1800000>;
+                regulator-max-microvolt = <1800000>;
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                    regulator-suspend-microvolt = <1800000>;
+                };
+            };
+
+            vdda0v9_image: LDO_REG1 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <900000>;
+                regulator-max-microvolt = <900000>;
+                regulator-name = "vdda0v9_image";
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                    regulator-suspend-microvolt = <900000>;
+                };
+            };
+
+            vdda_0v9: LDO_REG2 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <900000>;
+                regulator-max-microvolt = <900000>;
+                regulator-name = "vdda_0v9";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vdda0v9_pmu: LDO_REG3 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <900000>;
+                regulator-max-microvolt = <900000>;
+                regulator-name = "vdda0v9_pmu";
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                    regulator-suspend-microvolt = <900000>;
+                };
+            };
+
+            vccio_acodec: LDO_REG4 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <3300000>;
+                regulator-max-microvolt = <3300000>;
+                regulator-name = "vccio_acodec";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vccio_sd: LDO_REG5 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <1800000>;
+                regulator-max-microvolt = <3300000>;
+                regulator-name = "vccio_sd";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcc3v3_pmu: LDO_REG6 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <3300000>;
+                regulator-max-microvolt = <3300000>;
+                regulator-name = "vcc3v3_pmu";
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                    regulator-suspend-microvolt = <3300000>;
+                };
+            };
+
+            vcca_1v8: LDO_REG7 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <1800000>;
+                regulator-max-microvolt = <1800000>;
+                regulator-name = "vcca_1v8";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcca1v8_pmu: LDO_REG8 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <1800000>;
+                regulator-max-microvolt = <1800000>;
+                regulator-name = "vcca1v8_pmu";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcca1v8_image: LDO_REG9 {
+                regulator-always-on;
+                regulator-boot-on;
+                regulator-min-microvolt = <1800000>;
+                regulator-max-microvolt = <1800000>;
+                regulator-name = "vcca1v8_image";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcc_3v3: SWITCH_REG1 {
+                regulator-name = "vcc_3v3";
+                regulator-state-mem {
+                    regulator-off-in-suspend;
+                };
+            };
+
+            vcc3v3_sd: SWITCH_REG2 {
+                regulator-name = "vcc3v3_sd";
+                status = "disabled";
+                regulator-state-mem {
+                    regulator-on-in-suspend;
+                };
+            };
+
+        };
+    };
+};
+
+&i2s1_8ch {
+    pinctrl-names = "default";
+    pinctrl-0 = <&i2s1m1_sclktx &i2s1m1_sclkrx
+             &i2s1m1_lrcktx &i2s1m1_lrckrx
+             &i2s1m1_sdi0   &i2s1m1_sdi1
+             &i2s1m1_sdi2   &i2s1m1_sdi3
+             &i2s1m1_sdo0   &i2s1m1_sdo1
+             &i2s1m1_sdo2   &i2s1m1_sdo3>;
+    status = "disabled";
+};
+
+&pinctrl {  
+    sdio-pwrseq {
+        wifi_enable_h: wifi-enable-h {
+            rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+    
+    wireless-wlan {
+        wifi_host_wake_irq: wifi-host-wake-irq {
+            rockchip,pins = <2 RK_PB2 RK_FUNC_GPIO &pcfg_pull_down>;
+        };
+    };
+    
+    bt {
+        bt_enable_h: bt-enable-h {
+            rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+
+        bt_host_wake_l: bt-host-wake-l {
+            rockchip,pins = <2 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+
+        bt_wake_l: bt-wake-l {
+            rockchip,pins = <2 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+
+    leds {
+        led_pwr_enable_h: led-pwr-enable-h {
+            rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+        
+        led_wifi_enable_h: led-wifi-enable-h {
+            rockchip,pins = <0 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+        
+        led_eth_enable_h: led-eth-enable-h {
+            rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+
+        led_status_enable_h: led-status-enable-h {
+            rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+
+    pmic {
+        pmic_int_l: pmic-int-l {
+            rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+        };
+    };
+
+};
+
+&pmu_io_domains {
+    pmuio1-supply = <&vcc3v3_pmu>;
+    pmuio2-supply = <&vcc3v3_pmu>;
+    vccio1-supply = <&vcc_3v3>;
+    vccio2-supply = <&vcc_1v8>;
+    vccio3-supply = <&vccio_sd>;
+    vccio4-supply = <&vcc_1v8>;
+    vccio5-supply = <&vcc_3v3>;
+    vccio6-supply = <&vcc_3v3>;
+    vccio7-supply = <&vcc_3v3>;
+    status = "okay";
+};
+
+&saradc {
+    vref-supply = <&vcca_1v8>;
+    status = "okay";
+};
+
+&sdhci {
+    bus-width = <8>;
+    mmc-hs200-1_8v;
+    non-removable;
+    vmmc-supply = <&vcc_3v3>;
+    vqmmc-supply = <&vcc_1v8>;
+    status = "okay";
+};
+
+&sdmmc0 {
+    broken-cd;
+    bus-width = <4>;
+    cap-sd-highspeed;
+    disable-wp;
+    pinctrl-names = "default";
+    pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
+    vqmmc-supply = <&vccio_sd>;
+    status = "okay";
+};
+
+&sdmmc1 {
+    supports-sdio;
+    bus-width = <4>;
+    disable-wp;
+    cap-sd-highspeed;
+    cap-sdio-irq;
+    keep-power-in-suspend;
+    pinctrl-names = "default";
+    pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_cmd &sdmmc1_clk>;
+    non-removable;
+    mmc-pwrseq = <&sdio_pwrseq>;
+    status = "okay";
+
+};
+
+&tsadc {
+    status = "okay";
+};
+
+&uart1 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn &uart1m0_rtsn>;
+    status = "okay";
+    
+    bluetooth {
+        compatible = "brcm,bcm43438-bt";
+        clocks = <&rk809 1>;
+        clock-names = "lpo";
+        device-wakeup-gpios = <&gpio2 RK_PC1 GPIO_ACTIVE_HIGH>;
+        host-wakeup-gpios = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
+        shutdown-gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
+        max-speed = <1500000>;
+        pinctrl-names = "default";
+        pinctrl-0 = <&bt_host_wake_l &bt_wake_l &bt_enable_h>;
+        vbat-supply = <&vcc3v3_sys>;
+        vddio-supply = <&vcca1v8_pmu>;
+    };
+};
+
+&uart2 {
+    status = "okay";
+};
+
+&usb_host0_xhci {
+    dr_mode = "host";
+    status = "okay";
+};
+
+&usb_host0_ohci {
+    status = "okay";
+};
+
+&usb_host0_ehci {
+    status = "okay";
+};
+
+&usb2phy0 {
+    status = "okay";
+};
+
+&usb2phy0_host {
+    status = "okay";
+};
+
+&usb2phy0_otg {
+    status = "okay";
+};
+


### PR DESCRIPTION
kernel 5.10.y have some mpp-service to support mpp hardware enc/dec
so needed to add to kernel
dts file from here: https://github.com/tdleiyao/linux-6.1.y-unifreq/blob/main/arch/arm64/boot/dts/rockchip/rk3566-panther-x2.dts