### PR TITLE
Fix "WRITEABLE clk DebugFS SUPPORT HAS BEEN ENABLED IN THIS KERNEL" with CONFIG_ANDROID_BINDER_IPC enable

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -3131,7 +3131,7 @@ static int clk_dump_show(struct seq_file *s, void *data)
 DEFINE_SHOW_ATTRIBUTE(clk_dump);
 
 #ifdef CONFIG_ANDROID_BINDER_IPC
-#define CLOCK_ALLOW_WRITE_DEBUGFS
+#undef CLOCK_ALLOW_WRITE_DEBUGFS
 #else
 #undef CLOCK_ALLOW_WRITE_DEBUGFS
 #endif


### PR DESCRIPTION
after set `CONFIG_ANDROID_BINDER_IPC` enable, the `CLOCK_ALLOW_WRITE_DEBUGFS` activeated and the follow NOTICE show up in dmesg, it may compromise security on your system if enable CONFIG_ANDROID_BINDER_IPC for android support.
```
[  +0.000515] ********************************************************************
[  +0.000673] **     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE           **
[  +0.000652] **                                                                **
[  +0.000651] **  WRITEABLE clk DebugFS SUPPORT HAS BEEN ENABLED IN THIS KERNEL **
[  +0.000650] **                                                                **
[  +0.000650] ** This means that this kernel is built to expose clk operations  **
[  +0.000660] ** such as parent or rate setting, enabling, disabling, etc.      **
[  +0.000652] ** to userspace, which may compromise security on your system.    **
[  +0.000652] **                                                                **
[  +0.000650] ** If you see this message and you are not debugging the          **
[  +0.000650] ** kernel, report this immediately to your vendor!                **
[  +0.000324] usb 1-1: new high-speed USB device number 2 using xhci-hcd
[  +0.000332] **                                                                **
[  +0.001219] **     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE           **
[  +0.000653] ********************************************************************

```

1. `CONFIG_ANDROID_BINDER_IPC` does not define `CLOCK_ALLOW_WRITE_DEBUGFS` in mainline kernel
https://elixir.bootlin.com/linux/v5.10.209/source/drivers/clk/clk.c
2. radxa-repo have a patch to disable it too
https://github.com/radxa-repo/bsp/blob/main/linux/rockchip/0100-vendor/0008-Revert-ANDROID-clk-Enable-writable-debugfs-files.patch